### PR TITLE
ユーザが多い状態だとcreate-user-batchが正常に動作しない対応

### DIFF
--- a/CreateUser.js
+++ b/CreateUser.js
@@ -26,10 +26,17 @@ async function main() {
     headers['session'] = JSON.stringify(session);
     infoLog('session情報: ' + JSON.stringify(session));
 
+    // book作成最大数
+    const maxCount = config['bookCreateMaxCount'] ? config['bookCreateMaxCount'] : 1000;
+    // 前回作成した日から遡る日数
+    const dayBack = config['dayBackFromLastCreate'] ? config['dayBackFromLastCreate'] : 1;
+
+    const url = config['bookOperateService']['postUserBatch'] + '%3FmaxCount%3D' + maxCount + '%26dayBack%3D' + dayBack;
+
     // 利用者作成(バッチ)
     const postUserBatchBody = {};
     const postUserBatchOptions = {
-        url: config['bookOperateService']['postUserBatch'],
+        url: url,
         method: 'POST',
         headers: headers,
         json: postUserBatchBody

--- a/config/config.json
+++ b/config/config.json
@@ -1,0 +1,29 @@
+{
+  "bookOperateService": {
+    "postUserBatch": "http://application000001-service/pxr-block-proxy/pxr-block-proxy/?from_path=%2Fbook-operate&block=1000407&path=%2Fbook-operate%2Fuser%2Fbatch"
+  },
+  "bookCreateMaxCount": 30,
+  "dayBackFromLastCreate": 1,
+  "session": {
+    "loginId": "application000001_batch",
+    "auth": {
+      "member": {
+        "add": true,
+        "update": true,
+        "delete": true
+      },
+      "app-wf-user": {
+        "create": true
+      }
+    },
+    "block": {
+      "_value": 1000407,
+      "_ver": 1
+    },
+    "actor": {
+      "_value": 1000789,
+      "_ver": 1
+    }
+  },
+  "timezone": "Asia/Tokyo"
+}

--- a/config/log4js.config.json
+++ b/config/log4js.config.json
@@ -1,0 +1,33 @@
+{
+  "appenders": {
+    "ConsoleLogAppender": {
+      "type": "console"
+    },
+    "ApplicationLogAppender": {
+      "type": "dateFile",
+      "filename": "./efs/application000001/create-user-batch/application.log",
+      "pattern": ".yyyy-MM-dd",
+      "numBackups": 30,
+      "alwaysIncludePattern": false,
+      "layout": {
+        "type": "pattern",
+        "pattern": "[%d{yyyy-MM-dd hh:mm:ss.SSS}] [%p] %m"
+      }
+    }
+  },
+  "replaceConsole": true,
+  "categories": {
+    "default": {
+      "appenders": [
+        "ConsoleLogAppender"
+      ],
+      "level": "info"
+    },
+    "application": {
+      "appenders": [
+        "ApplicationLogAppender"
+      ],
+      "level": "info"
+    }
+  }
+}


### PR DESCRIPTION
## 修正内容
* create-user-batch-container.yamlのConfigMap内から、修正済みのconfig.jsonとlog4js.config.jsonをコピー。
  * config.json
    * "bookCreateMaxCount": book作成最大数
    * "dayBackFromLastCreate": 前回作成した日から遡る日数
  * log4js.config.json
    * log4jsの[Documentation](https://www.npmjs.com/package/log4js#documentation)を参照。

fixes #1
